### PR TITLE
feat: 회원 가입 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation "org.springframework.data:spring-data-envers"
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/wanted/n/controller/UserController.java
+++ b/src/main/java/wanted/n/controller/UserController.java
@@ -1,0 +1,45 @@
+package wanted.n.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wanted.n.dto.UserSignUpRequest;
+import wanted.n.service.EmailService;
+import wanted.n.service.UserService;
+
+import javax.validation.Valid;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static wanted.n.enums.MailComponents.VERIFICATION_MESSAGE;
+import static wanted.n.enums.MailComponents.VERIFICATION_SUBJECT;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@Api(tags = "User API", description = "사용자와 관련된 API")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+    private final EmailService emailService;
+
+    @PostMapping("/sign-up")
+    @ApiOperation(value = "회원가입", notes = "사용자가 회원정보를 입력하여 회원가입을 진행합니다.")
+    public ResponseEntity<Void> registerUser(@Valid @RequestBody UserSignUpRequest userSignUpRequest) {
+
+        // 입력받은 정보로 회원가입 (회원상태 : 미인증)
+        userService.registerUser(userSignUpRequest);
+
+        // 회원가입 인원에게 인증메일 전송
+        emailService.sendEmail(
+                userSignUpRequest.getEmail(), VERIFICATION_SUBJECT, VERIFICATION_MESSAGE
+        );
+
+        return ResponseEntity.status(CREATED).build();
+    }
+
+}

--- a/src/main/java/wanted/n/domain/User.java
+++ b/src/main/java/wanted/n/domain/User.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.envers.AuditOverride;
+import wanted.n.dto.UserSignUpRequest;
 import wanted.n.enums.UserRole;
 import wanted.n.enums.UserStatus;
 
@@ -16,7 +17,7 @@ import javax.persistence.*;
 @Builder
 @AuditOverride(forClass = BaseEntity.class)
 @Entity
-public class User extends BaseEntity{
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,4 +40,13 @@ public class User extends BaseEntity{
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 
+    public static User from(UserSignUpRequest userSignUpRequest) {
+        return User.builder()
+                .account(userSignUpRequest.getAccount())
+                .email(userSignUpRequest.getEmail())
+                .password(userSignUpRequest.getPassword())
+                .userRole(UserRole.ROLE_USER)
+                .userStatus(UserStatus.UNVERIFIED)
+                .build();
+    }
 }

--- a/src/main/java/wanted/n/dto/UserSignUpRequest.java
+++ b/src/main/java/wanted/n/dto/UserSignUpRequest.java
@@ -1,0 +1,32 @@
+package wanted.n.dto;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ApiModel(value = "회원가입 Request", description = "사용자가 회원가입을 위해 입력하는 정보")
+public class UserSignUpRequest {
+
+    @NotBlank(message = "계정을 입력해 주세요.")
+    private String account;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Size(min = 10, max = 20, message = "비밀번호는 10자 이상 20자 이하로 입력해 주세요.")
+    private String password;
+
+    public void setPassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+}

--- a/src/main/java/wanted/n/enums/MailComponents.java
+++ b/src/main/java/wanted/n/enums/MailComponents.java
@@ -1,0 +1,19 @@
+package wanted.n.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MailComponents {
+    VERIFICATION_SUBJECT("회원가입 인증 메일입니다."),
+
+    VERIFICATION_MESSAGE(
+            "SNS-FEED 회원가입을 축하합니다! \n" +
+                    "아래 코드를 입력하여 회원인증을 완료하신 후 \n " +
+                    "서비스를 사용하실 수 있습니다. \n" +
+                    "코드 : %s"
+    );
+
+    private final String content;
+}

--- a/src/main/java/wanted/n/exception/ErrorCode.java
+++ b/src/main/java/wanted/n/exception/ErrorCode.java
@@ -9,7 +9,14 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     //GlobalException
     UNDEFINED_EXCEPTION(HttpStatus.BAD_REQUEST, "알 수 없는 오류입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+    //UserException
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    DUPLICATED_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 가입된 계정입니다."),
+    INVALID_PASSWORD_AT_LEAST_2_TYPES(HttpStatus.BAD_REQUEST, "숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다."),
+    INVALID_PASSWORD_ONLY_DIGITS(HttpStatus.BAD_REQUEST, "숫자로만 이루어진 비밀번호는 사용할 수 없습니다."),
+    INVALID_PASSWORD_CONSECUTIVE_CHARACTERS(HttpStatus.BAD_REQUEST, "연속된 문자가 3개 이상 포함되면 사용할 수 없습니다"),
+    INVALID_PASSWORD_USUAL_PASSWORD(HttpStatus.BAD_REQUEST, "통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/wanted/n/exception/ErrorCode.java
+++ b/src/main/java/wanted/n/exception/ErrorCode.java
@@ -10,11 +10,14 @@ public enum ErrorCode {
     //GlobalException
     UNDEFINED_EXCEPTION(HttpStatus.BAD_REQUEST, "알 수 없는 오류입니다."),
 
+    //EmailException
+    EMAIL_SENDING_FAILED(HttpStatus.BAD_REQUEST, "이메일 전송에 실패했습니다."),
+
     //UserException
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATED_ACCOUNT(HttpStatus.BAD_REQUEST, "이미 가입된 계정입니다."),
     INVALID_PASSWORD_AT_LEAST_2_TYPES(HttpStatus.BAD_REQUEST, "숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다."),
-    INVALID_PASSWORD_ONLY_DIGITS(HttpStatus.BAD_REQUEST, "숫자로만 이루어진 비밀번호는 사용할 수 없습니다."),
+    INVALID_PASSWORD_SAME_CHARACTERS(HttpStatus.BAD_REQUEST, "동일한 문자가 3개 이상 연속되면 사용할 수 없습니다"),
     INVALID_PASSWORD_CONSECUTIVE_CHARACTERS(HttpStatus.BAD_REQUEST, "연속된 문자가 3개 이상 포함되면 사용할 수 없습니다"),
     INVALID_PASSWORD_USUAL_PASSWORD(HttpStatus.BAD_REQUEST, "통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.");
 

--- a/src/main/java/wanted/n/repository/UserRepository.java
+++ b/src/main/java/wanted/n/repository/UserRepository.java
@@ -7,8 +7,9 @@ import wanted.n.domain.User;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User,Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByAccount(String accountInputted);
 }

--- a/src/main/java/wanted/n/service/EmailService.java
+++ b/src/main/java/wanted/n/service/EmailService.java
@@ -1,0 +1,88 @@
+package wanted.n.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import wanted.n.enums.MailComponents;
+import wanted.n.exception.CustomException;
+
+import java.util.UUID;
+
+import static wanted.n.enums.MailComponents.VERIFICATION_SUBJECT;
+import static wanted.n.exception.ErrorCode.EMAIL_SENDING_FAILED;
+
+/**
+ * 이메일 관련 서비스
+ */
+@RequiredArgsConstructor
+@Service
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    /**
+     * 이메일을 전송하는 메서드 (인증번호 / 비밀번호 초기화 시)
+     *
+     * @param to      수신자 이메일 주소
+     * @param subject 이메일 주제
+     * @param text    이메일 내용
+     */
+    public void sendEmail(String to, MailComponents subject, MailComponents text) {
+
+        SimpleMailMessage mail = new SimpleMailMessage();
+
+        // 인증 메일 일 경우 인증 코드를 보내는 메일 생성
+        if (subject.equals(VERIFICATION_SUBJECT)) {
+            createMail(mail, to, subject, text, 6);
+        }
+
+        send(mail);
+    }
+
+    /**
+     * 인증 코드/임시 비밀번호 를 생성하는 메서드
+     *
+     * @param length 생성할 인증 코드의 길이
+     * @return 생성된 인증 코드 / 바밀번호
+     */
+    private String createUUID(int length) {
+        return UUID.randomUUID()
+                .toString()
+                .replace("-", "")
+                .substring(0, length);
+    }
+
+    /**
+     * SimpleMailMessage 객체를 생성하는 메서드
+     *
+     * @param to      수신자 이메일 주소
+     * @param subject 이메일 주제
+     * @param text    이메일 내용
+     * @param length  생성할 인증 코드의 길이
+     * @return 생성된 SimpleMailMessage 객체
+     */
+    private SimpleMailMessage createMail(SimpleMailMessage mail,
+                                         String to,
+                                         MailComponents subject,
+                                         MailComponents text, int length) {
+        mail.setTo(to);
+        mail.setSubject(subject.getContent());
+        mail.setText(String.format(text.getContent(), createUUID(length)));
+        return mail;
+    }
+
+    /**
+     * 이메일을 전송하는 메서드
+     *
+     * @param mail SimpleMailMessage 객체
+     */
+    private void send(SimpleMailMessage mail) {
+        try {
+            javaMailSender.send(mail);
+        } catch (MailException e) {
+            throw new CustomException(EMAIL_SENDING_FAILED);
+        }
+    }
+}

--- a/src/main/java/wanted/n/service/UserService.java
+++ b/src/main/java/wanted/n/service/UserService.java
@@ -1,0 +1,71 @@
+package wanted.n.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wanted.n.domain.User;
+import wanted.n.dto.UserSignUpRequest;
+import wanted.n.exception.CustomException;
+import wanted.n.repository.UserRepository;
+import wanted.n.utility.ValidationUtil;
+
+import static wanted.n.exception.ErrorCode.*;
+
+/**
+ * 사용자 관련 서비스
+ */
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 사용자 회원가입을 처리하는 메서드
+     *
+     * @param userSignUpRequest 사용자 회원가입 요청 데이터
+     */
+    @Transactional
+    public void registerUser(UserSignUpRequest userSignUpRequest) {
+
+        String password = userSignUpRequest.getPassword();
+
+        // 계정 중복 체크
+        userRepository.findByAccount(userSignUpRequest.getAccount())
+                .ifPresent(user -> {
+                    throw new CustomException(DUPLICATED_ACCOUNT);
+                });
+
+        // 비밀번호 유효성 체크
+        validatePassword(password);
+
+        // 비밀번호를 암호화하여 저장
+        userSignUpRequest.setPassword(passwordEncoder.encode(password));
+        userRepository.save(User.from(userSignUpRequest));
+    }
+
+    /**
+     * 비밀번호의 유효성을 검사하는 메서드 (private)
+     *
+     * @param password 검사할 비밀번호
+     */
+    private void validatePassword(String password) {
+        if (ValidationUtil.hasSameCharacters(password)) {
+            throw new CustomException(INVALID_PASSWORD_SAME_CHARACTERS);
+        }
+
+        if (ValidationUtil.hasConsecutiveCharacters(password)) {
+            throw new CustomException(INVALID_PASSWORD_CONSECUTIVE_CHARACTERS);
+        }
+
+        if (ValidationUtil.isUsualPassword(password)) {
+            throw new CustomException(INVALID_PASSWORD_USUAL_PASSWORD);
+        }
+
+        if (ValidationUtil.containsTwoOrMoreCharacterTypes(password)) {
+            throw new CustomException(INVALID_PASSWORD_AT_LEAST_2_TYPES);
+        }
+    }
+}

--- a/src/main/java/wanted/n/utility/ValidationUtil.java
+++ b/src/main/java/wanted/n/utility/ValidationUtil.java
@@ -1,0 +1,85 @@
+package wanted.n.utility;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * 비밀번호 유효성 검사를 위한 유틸 클래스 (총 4가지 조건으로 검사)
+ */
+@UtilityClass
+public class ValidationUtil {
+
+    /* 구글기준 2023 자주사용되는 비밀번호 30개 */
+    private final List<String> USUAL_PASSWORD_LIST =
+            Arrays.asList(
+                    "1234", "27653", "12345", "qwerty", "dragon", "111111", "123321", "123456",
+                    "654321", "abc123", "000000", "monkey", "1234567", "letmein", "12345678",
+                    "password", "iloveyou", "sunshine", "zaq12wsx", "1qaz2wsx", "password12",
+                    "superman", "princess", "1q2w3e4r", "123456789", "qwerty123", "asdfghjkl",
+                    "1234567890", "qwertyuiop"
+            );
+
+    /* 비밀번호 조건: 숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다.*/
+    public static boolean containsTwoOrMoreCharacterTypes(String password) {
+        int characterTypeCount = 0;
+
+        //문자가 포함되어 있는지
+        if (password.matches(".*[a-zA-Z].*")) {
+            characterTypeCount++;
+        }
+
+        //숫자가 포함되어 있는지
+        if (password.matches(".*[0-9].*")) {
+            characterTypeCount++;
+        }
+
+        //특수문자가 포함되어 있는지
+        if (password.matches(".*[!@#$%^&*()].*")) {
+            characterTypeCount++;
+        }
+
+        //문자, 숫자, 특수문자 중 2가지 이상을 포함하고 있으면 false, 아니면 true
+        return characterTypeCount < 2;
+    }
+
+    /* 비밀번호 조건: 같은 문자가 3개 이상 포함되면 사용할 수 없습니다.*/
+    public static boolean hasSameCharacters(String password) {
+        return IntStream.range(0, password.length() - 3 + 1)
+                .anyMatch(i -> password.substring(i, i + 3)
+                        .chars()
+                        .allMatch(c -> c == password.charAt(i)));
+    }
+
+    /* 비밀번호 조건: 연속된 문자 및 숫자가 3개 이상 포함되면 사용할 수 없습니다.*/
+    public static boolean hasConsecutiveCharacters(String password) {
+        return IntStream.range(0, password.length() - 2)
+                .anyMatch(i -> {
+                    char currentChar = password.charAt(i);
+                    char nextChar = password.charAt(i + 1);
+                    char secondNextChar = password.charAt(i + 2);
+                    return isSequential(currentChar, nextChar, secondNextChar);
+                });
+    }
+
+    /* 연속된 문자/숫자인지 판별 */
+    private boolean isSequential(char a, char b, char c) {
+        if ((Character.isLetter(a) && Character.isLetter(b) && Character.isLetter(c)) ||
+                (Character.isDigit(a) && Character.isDigit(b) && Character.isDigit(c))) {
+            int diff1 = b - a;
+            int diff2 = c - b;
+            if (diff1 == 1 && diff2 == 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /* 비밀번호 조건: 통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다. */
+    public static boolean isUsualPassword(String password) {
+        return USUAL_PASSWORD_LIST.contains(password);
+    }
+}
+

--- a/src/test/java/wanted/n/service/UserSignUpTest.java
+++ b/src/test/java/wanted/n/service/UserSignUpTest.java
@@ -1,0 +1,153 @@
+package wanted.n.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import wanted.n.domain.User;
+import wanted.n.dto.UserSignUpRequest;
+import wanted.n.exception.CustomException;
+import wanted.n.repository.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@DisplayName("사용자 회원가입 테스트")
+class UserSignUpTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private UserService userService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        userService = new UserService(userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("성공")
+    public void testUserSignUp_Success() {
+        //given
+        UserSignUpRequest userSignUpRequest = UserSignUpRequest.builder()
+                .account("테스트계정")
+                .email("email@email.email")
+                .password("daehanminkuk193!")
+                .build();
+
+        when(userRepository.findByAccount(userSignUpRequest.getAccount()))
+                .thenReturn(Optional.empty());
+        //when
+        userService.registerUser(userSignUpRequest);
+
+        //then
+        verify(userRepository, times(1))
+                .save(argThat(user ->
+                        user.getAccount().equals(userSignUpRequest.getAccount()) &&
+                                user.getEmail().equals(userSignUpRequest.getEmail())
+                ));
+    }
+
+    @Test
+    @DisplayName("실패 - 같은문자 3번이상 반복")
+    public void testUserSignUp_Fail_PW_Numeric_Only() {
+        //given
+        UserSignUpRequest userSignUpRequest = UserSignUpRequest.builder()
+                .account("테스트계정")
+                .email("email@email.email")
+                .password("cbaaanbok")
+                .build();
+
+        when(userRepository.findByAccount(userSignUpRequest.getAccount()))
+                .thenReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> userService.registerUser(userSignUpRequest))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("동일한 문자가 3개 이상 연속되면 사용할 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("실패 - 영숫자특문(2개이상) 조합이 아닌 비밀번호")
+    public void testUserSignUp_Fail_PW_Too_Short() {
+        //given
+        UserSignUpRequest userSignUpRequest = UserSignUpRequest.builder()
+                .account("테스트계정")
+                .email("email@email.email")
+                .password("ajhgfasc")
+                .build();
+
+        when(userRepository.findByAccount(userSignUpRequest.getAccount()))
+                .thenReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> userService.registerUser(userSignUpRequest))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("실패 - 연속 문자가 포함된 비밀번호")
+    public void testUserSignUp_Fail_PW_Continual() {
+        //given
+        UserSignUpRequest userSignUpRequest = UserSignUpRequest.builder()
+                .account("테스트계정")
+                .email("email@email.email")
+                .password("abcbanbok!")
+                .build();
+
+        when(userRepository.findByAccount(userSignUpRequest.getAccount()))
+                .thenReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> userService.registerUser(userSignUpRequest))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("연속된 문자가 3개 이상 포함되면 사용할 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("실패 - 통상적인 비밀번호")
+    public void testUserSignUp_Fail_PW_Common() {
+        //given
+        UserSignUpRequest userSignUpRequest = UserSignUpRequest.builder()
+                .account("테스트계정")
+                .email("email@email.email")
+                .password("password12")
+                .build();
+
+        when(userRepository.findByAccount(userSignUpRequest.getAccount()))
+                .thenReturn(Optional.empty());
+
+        //when&then
+        assertThatThrownBy(() -> userService.registerUser(userSignUpRequest))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("실패 - 계정 중복")
+    public void testUserSignUp_Fail_ACC_Duplicated() {
+        //given
+        UserSignUpRequest userSignUpRequest = UserSignUpRequest.builder()
+                .account("테스트계정")
+                .email("email@email.email")
+                .password("test1093353")
+                .build();
+
+        when(userRepository.findByAccount(userSignUpRequest.getAccount()))
+                .thenReturn(Optional.of(new User()));
+
+        //when&then
+        assertThatThrownBy(() -> userService.registerUser(userSignUpRequest))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 가입된 계정입니다.");
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 회원가입 기능 추가
- 이메일 전송 기능 추가

### 변경 사항(추가시엔 추가사항)
- 사용자 회원가입 기능 추가
   - 회원가입 프로세스
     1. 계정 중복 확인 (레포지토리 조회)
     2. Email 형식 확인(`@Valid` 통해 검증)
     3. 비밀번호 검증은 총 5개를 진행. (길이-`@Valid`통해 검증, 이외 4개검증 - `ValidationUtil`사용)
     4. a~c 과정 통과시 비밀번호 암호화 하여 `User` 생성(`Role`은 유저, `Status`는 미인증)
     6. 입력된 이메일로 인증메일 전송 (인증코드(6자리 난수) 포함)
     7. (작업예정) 이메일(키):인증코드(값) 을 레디스에 저장
     8. (작업예정) 이후 사용자가 이메일과 인증코드 입력 시 `redis` 내 데이터 <-> 인증코드 비교 후 인증처리
     
     
- 이메일 전송 기능 추가
   - 회원가입 및 추후 개발할 비밀번호 초기화에도 사용될 예정
      - 해당 부분 코드중복방지 위해 `MailComponents` `enum` 파일을 추가하여 `subject`,`text` 관리. 
      - 난수 생성도 길이를 통한 생성으로 구분하여 코드 중복 최소화 (인증코드 6 , 임시비밀번호 10)
      - `SMTP` 서버와 이메일 전송을 테스트하는 것은 단위 테스트에는 적합하지 않아, API 테스트로 대체 (정상동작)
### 특이 사항
- 사용자 이메일 인증 API 는 추후 팀원이 작업한 `RedisConfig` 파일 올라오면 작업 예정

### 테스트
- [x] 테스트 코드
- [x] api 테스트

### 관련 이슈(옵셔널)
- 없음