### PR TITLE
feat: Redis 설정 및 Log 저장 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/wanted/n/config/RedisConfig.java
+++ b/src/main/java/wanted/n/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package wanted.n.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/wanted/n/config/WebConfig.java
+++ b/src/main/java/wanted/n/config/WebConfig.java
@@ -1,0 +1,22 @@
+package wanted.n.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import wanted.n.filter.LogFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig {
+
+    private final LogFilter logFilter;
+
+    @Bean
+    public FilterRegistrationBean<LogFilter> customFilter() {
+        FilterRegistrationBean<LogFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(logFilter);
+        registrationBean.addUrlPatterns("/log/*"); // 임시 log 처리 패턴으로 지정
+        return registrationBean;
+    }
+}

--- a/src/main/java/wanted/n/controller/LogController.java
+++ b/src/main/java/wanted/n/controller/LogController.java
@@ -1,0 +1,23 @@
+package wanted.n.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import wanted.n.dto.LogPostingDTO;
+import wanted.n.service.RedisService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/log")
+public class LogController {
+
+    private final RedisService redisService;
+
+    /**
+     * 임시 posting 저장 api
+     */
+    @GetMapping("/save")
+    public String savePosting(@RequestBody LogPostingDTO dto) {
+        return "LogController.savePosting";
+    }
+
+}

--- a/src/main/java/wanted/n/dto/LogDTO.java
+++ b/src/main/java/wanted/n/dto/LogDTO.java
@@ -1,0 +1,23 @@
+package wanted.n.dto;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.Column;
+
+/**
+ * 특정 태그에 대한 log 데이터
+ */
+@Getter
+public class LogDTO {
+    private String tag;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private long createdAt;
+
+    public LogDTO(String tag, long createdAt) {
+        this.tag = tag;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/wanted/n/dto/LogPostingDTO.java
+++ b/src/main/java/wanted/n/dto/LogPostingDTO.java
@@ -1,0 +1,14 @@
+package wanted.n.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+/**
+ * 임시 posting 데이터
+ */
+@Getter
+@Setter
+public class LogPostingDTO {
+    private List<String> tag;
+}

--- a/src/main/java/wanted/n/filter/LogFilter.java
+++ b/src/main/java/wanted/n/filter/LogFilter.java
@@ -1,0 +1,42 @@
+package wanted.n.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import wanted.n.dto.LogDTO;
+import wanted.n.dto.LogPostingDTO;
+import wanted.n.service.RedisService;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+@RequiredArgsConstructor
+@Component
+public class LogFilter implements Filter {
+
+    private final RedisService redisService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        String requestBody = new String(request.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+        // LogPostingDTO 객체로 변환
+        LogPostingDTO dto = objectMapper.readValue(requestBody, LogPostingDTO.class);
+
+        for (String tag : dto.getTag()) {
+            // tag가 존재하는 값인 경우
+            redisService.saveObjectAsJson(new LogDTO(tag, System.currentTimeMillis()));
+        }
+        System.out.println("LogFilter.doFilter");
+        filterChain.doFilter(request, servletResponse);
+    }
+}

--- a/src/main/java/wanted/n/filter/LogFilter.java
+++ b/src/main/java/wanted/n/filter/LogFilter.java
@@ -36,7 +36,6 @@ public class LogFilter implements Filter {
             // tag가 존재하는 값인 경우
             redisService.saveObjectAsJson(new LogDTO(tag, System.currentTimeMillis()));
         }
-        System.out.println("LogFilter.doFilter");
         filterChain.doFilter(request, servletResponse);
     }
 }

--- a/src/main/java/wanted/n/service/RedisService.java
+++ b/src/main/java/wanted/n/service/RedisService.java
@@ -1,0 +1,29 @@
+package wanted.n.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import wanted.n.dto.LogDTO;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private final static String KEY_TAG = "tag:";
+
+    /**
+     * 객체를 JSON 형식으로 변환시켜 redis의 sorted set에 저장합니다.
+     *
+     * @throws JsonProcessingException JSON 변환 예외 발생 처리
+     */
+    public void saveObjectAsJson(LogDTO log) throws JsonProcessingException {
+        String jsonValue = objectMapper.writeValueAsString(log);
+        redisTemplate.opsForZSet().add(KEY_TAG + log.getTag(), jsonValue, log.getCreatedAt());
+    }
+
+}


### PR DESCRIPTION
### 작업 내용
- `redis` 의존성 및 설정 추가
- log 데이터 저장 로직 추가
- tag 관련 필터 추가

### 변경 사항(추가시엔 추가사항)
- Sorted Set 형태로 로그 데이터를 redis에 저장
- tag 저장을 위한 LogFilter 필터 연결


### 특이 사항
- yml에 redis 설정 필요
- 추후 posting 생성에 사용할 api와 필터를 연결할 예정

### 테스트
- 없음

### 관련 이슈(옵셔널),
- 없음