### PR TITLE
feat: hot hastags 저장

### DIFF
--- a/src/main/java/wanted/n/config/RedisConfig.java
+++ b/src/main/java/wanted/n/config/RedisConfig.java
@@ -5,7 +5,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @EnableRedisRepositories
 @Configuration
@@ -20,5 +23,20 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        // Key는 문자열로 직렬화
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+        // Value는 JSON으로 직렬화
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
     }
 }

--- a/src/main/java/wanted/n/dto/LogDTO.java
+++ b/src/main/java/wanted/n/dto/LogDTO.java
@@ -1,5 +1,6 @@
 package wanted.n.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 
@@ -9,15 +10,11 @@ import javax.persistence.Column;
  * 특정 태그에 대한 log 데이터
  */
 @Getter
+@AllArgsConstructor
 public class LogDTO {
     private String tag;
 
     @CreatedDate
     @Column(updatable = false)
     private long createdAt;
-
-    public LogDTO(String tag, long createdAt) {
-        this.tag = tag;
-        this.createdAt = createdAt;
-    }
 }

--- a/src/main/java/wanted/n/exception/ErrorCode.java
+++ b/src/main/java/wanted/n/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
     INVALID_PASSWORD_AT_LEAST_2_TYPES(HttpStatus.BAD_REQUEST, "숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다."),
     INVALID_PASSWORD_SAME_CHARACTERS(HttpStatus.BAD_REQUEST, "동일한 문자가 3개 이상 연속되면 사용할 수 없습니다"),
     INVALID_PASSWORD_CONSECUTIVE_CHARACTERS(HttpStatus.BAD_REQUEST, "연속된 문자가 3개 이상 포함되면 사용할 수 없습니다"),
-    INVALID_PASSWORD_USUAL_PASSWORD(HttpStatus.BAD_REQUEST, "통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.");
+    INVALID_PASSWORD_USUAL_PASSWORD(HttpStatus.BAD_REQUEST, "통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다."),
+
+    // IOException
+    JSON_EXCEPTION(HttpStatus.BAD_REQUEST, "Json 직렬화에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/wanted/n/filter/LogFilter.java
+++ b/src/main/java/wanted/n/filter/LogFilter.java
@@ -32,7 +32,7 @@ public class LogFilter implements Filter {
 
             // LogPostingDTO 객체로 변환
             for (String t : objectMapper.readValue(requestBody, LogPostingDTO.class).getTag()) {
-                redisService.saveObjectAsJson(new LogDTO(t, System.currentTimeMillis()));
+                redisService.saveLogAsJson(new LogDTO(t, System.currentTimeMillis()));
             }
         }
 

--- a/src/main/java/wanted/n/filter/LogFilter.java
+++ b/src/main/java/wanted/n/filter/LogFilter.java
@@ -24,16 +24,18 @@ public class LogFilter implements Filter {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
-            throws IOException, ServletException {
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
-        String requestBody = new String(request.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
-        // LogPostingDTO 객체로 변환
-        for (String t : objectMapper.readValue(requestBody, LogPostingDTO.class).getTag()) {
-            redisService.saveObjectAsJson(new LogDTO(t, System.currentTimeMillis()));
+        if (request.getRequestURI().contains("/log")) {
+            String requestBody = new String(request.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+            // LogPostingDTO 객체로 변환
+            for (String t : objectMapper.readValue(requestBody, LogPostingDTO.class).getTag()) {
+                redisService.saveObjectAsJson(new LogDTO(t, System.currentTimeMillis()));
+            }
         }
 
-        filterChain.doFilter(request, servletResponse);
+        filterChain.doFilter(servletRequest, servletResponse);
     }
 }

--- a/src/main/java/wanted/n/filter/LogFilter.java
+++ b/src/main/java/wanted/n/filter/LogFilter.java
@@ -30,12 +30,10 @@ public class LogFilter implements Filter {
         String requestBody = new String(request.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
         // LogPostingDTO 객체로 변환
-        LogPostingDTO dto = objectMapper.readValue(requestBody, LogPostingDTO.class);
-
-        for (String tag : dto.getTag()) {
-            // tag가 존재하는 값인 경우
-            redisService.saveObjectAsJson(new LogDTO(tag, System.currentTimeMillis()));
+        for (String t : objectMapper.readValue(requestBody, LogPostingDTO.class).getTag()) {
+            redisService.saveObjectAsJson(new LogDTO(t, System.currentTimeMillis()));
         }
+
         filterChain.doFilter(request, servletResponse);
     }
 }

--- a/src/main/java/wanted/n/service/LogService.java
+++ b/src/main/java/wanted/n/service/LogService.java
@@ -1,0 +1,49 @@
+package wanted.n.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LogService {
+    private final RedisService redisService;
+
+    private final static String KEY_TAG = "tag:"; // 태그를 저장하는 키
+    private final static String KEY_HOT_HASHTAG = "tags"; // 핫 해시태그 리스트를 저장하는 키
+    private final static Integer TIMES = 3 * 60 * 60 * 1000;
+
+    // 최근 3시간 많이 이용된 tag redis에 저장
+    public void getCountByTagForLast3Hours() {
+        long threeHoursAgoTime = System.currentTimeMillis() - TIMES;
+        Set<String> tags = redisService.findDataWithKey("*" + KEY_TAG + "*");
+
+        List<String> sortedTags = countTags(tags, threeHoursAgoTime);
+        redisService.saveSortedTags(sortedTags, KEY_HOT_HASHTAG);
+    }
+
+    // 태그마다 시간 범위 내의 개수를 세어서 내림차순으로 정렬된 결과 반환
+    private  List<String> countTags(Set<String> tags, long startTime) {
+        Map<String, Long> tagCounts = new HashMap<>();
+        long now = System.currentTimeMillis();
+
+        for (String tag : tags) {
+            long count = redisService.countDataWithTime(tag, startTime, now);
+            tagCounts.put(tag, count);
+        }
+        return sortTagsByCount(tagCounts);
+    }
+
+    // 내림차순으로 태그 Map 정렬
+    private List<String> sortTagsByCount(Map<String, Long> tagCounts) {
+        return tagCounts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/wanted/n/service/LogService.java
+++ b/src/main/java/wanted/n/service/LogService.java
@@ -1,6 +1,8 @@
 package wanted.n.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -9,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@EnableScheduling
 @Service
 @RequiredArgsConstructor
 public class LogService {
@@ -18,7 +21,8 @@ public class LogService {
     private final static String KEY_HOT_HASHTAG = "tags"; // 핫 해시태그 리스트를 저장하는 키
     private final static Integer TIMES = 3 * 60 * 60 * 1000;
 
-    // 최근 3시간 많이 이용된 tag redis에 저장
+    // 최근 3시간 많이 사용된 태그 순으로 리스트 저장
+    @Scheduled(cron = "0 0 */1 * * *") // 매 1시간마다 실행
     public void getCountByTagForLast3Hours() {
         long threeHoursAgoTime = System.currentTimeMillis() - TIMES;
         Set<String> tags = redisService.findDataWithKey("*" + KEY_TAG + "*");
@@ -46,4 +50,5 @@ public class LogService {
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/wanted/n/service/RedisService.java
+++ b/src/main/java/wanted/n/service/RedisService.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import wanted.n.dto.LogDTO;
 
+import java.util.concurrent.TimeUnit;
+
 @Service
 @RequiredArgsConstructor
 public class RedisService {
@@ -15,15 +17,21 @@ public class RedisService {
     private final ObjectMapper objectMapper;
 
     private final static String KEY_TAG = "tag:";
+    private final static Integer TIMES = 3 * 60 * 60 * 1000;
 
     /**
-     * 객체를 JSON 형식으로 변환시켜 redis의 sorted set에 저장합니다.
+     * 객체를 JSON 형식으로 변환시켜 3시간 동안 redis의 sorted set에 저장합니다.
      *
      * @throws JsonProcessingException JSON 변환 예외 발생 처리
      */
     public void saveObjectAsJson(LogDTO log) throws JsonProcessingException {
         String jsonValue = objectMapper.writeValueAsString(log);
-        redisTemplate.opsForZSet().add(KEY_TAG + log.getTag(), jsonValue, log.getCreatedAt());
+        long currentTimeMillis = System.currentTimeMillis();
+
+        redisTemplate.opsForZSet().add(KEY_TAG + log.getTag(), jsonValue, currentTimeMillis);
+
+        // TTL 3시간으로 설정
+        redisTemplate.expire(KEY_TAG + log.getTag(), TIMES, TimeUnit.SECONDS);
     }
 
 }

--- a/src/main/java/wanted/n/service/RedisService.java
+++ b/src/main/java/wanted/n/service/RedisService.java
@@ -3,35 +3,68 @@ package wanted.n.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import wanted.n.dto.LogDTO;
+import wanted.n.exception.CustomException;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static wanted.n.exception.ErrorCode.JSON_EXCEPTION;
 
 @Service
 @RequiredArgsConstructor
 public class RedisService {
 
-    private final StringRedisTemplate redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
-    private final static String KEY_TAG = "tag:";
+    private final static String KEY_TAG = "tag:"; // 태그를 저장하는 키
+    private final static String KEY_HOT_HASHTAG = "tags"; // 핫 해시태그 리스트를 저장하는 키
     private final static Integer TIMES = 3 * 60 * 60 * 1000;
 
-    /**
-     * 객체를 JSON 형식으로 변환시켜 3시간 동안 redis의 sorted set에 저장합니다.
-     *
-     * @throws JsonProcessingException JSON 변환 예외 발생 처리
-     */
-    public void saveObjectAsJson(LogDTO log) throws JsonProcessingException {
-        String jsonValue = objectMapper.writeValueAsString(log);
+    // 객체를 JSON 형식으로 변환시켜 sorted set 저장
+    public void saveLogAsJson(LogDTO log) {
+        String jsonValue;
+        try {
+            jsonValue = objectMapper.writeValueAsString(log);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(JSON_EXCEPTION);
+        }
         long currentTimeMillis = System.currentTimeMillis();
 
         redisTemplate.opsForZSet().add(KEY_TAG + log.getTag(), jsonValue, currentTimeMillis);
 
         // TTL 3시간으로 설정
         redisTemplate.expire(KEY_TAG + log.getTag(), TIMES, TimeUnit.SECONDS);
+    }
+
+    // key로 데이터를 조회
+    public Set<String> findDataWithKey(String key) {
+        return redisTemplate.keys(key);
+    }
+
+    // key에 따라 특정 시간 동안 데이터 개수 반환
+    public long countDataWithTime(String key, double startTime, double lastTime) {
+        return Objects.requireNonNullElse(redisTemplate.opsForZSet()
+                .count(key, startTime, lastTime), 0).longValue();
+    }
+
+    // 태그 리스트를 저장
+    public void saveSortedTags(List<String> sortedTags, String key) {
+        redisTemplate.delete(key);
+        long currentTimeMillis = System.currentTimeMillis();
+
+        List<String> tagNames = sortedTags.stream()
+                .map(tag -> tag.substring(KEY_TAG.length()))
+                .collect(Collectors.toList());
+        for (String name : tagNames) {
+            redisTemplate.opsForZSet().add(KEY_HOT_HASHTAG, name, currentTimeMillis);
+        }
     }
 
 }


### PR DESCRIPTION
### 작업 내용
- 코드컨벤션 적용
- hot hastags 저장
- redis 데이터에 TTL 추가

### 변경 사항(추가시엔 추가사항)
- 스케줄링으로 0시부터 1시간마다 많이 사용한 tag 정보 갱신
- count를 내림차순으로 많이 사용한 태그 저장
- 많이 사용한 태그도 redis에 저장


### 특이 사항
- 없음

### 테스트
- 없음

### 관련 이슈(옵셔널),
- 없음